### PR TITLE
ci: add github workflow for lint and code format check

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,32 @@
+name: Node.JS CI - Check Lint and Code Format
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+      - name: Build
+        run: |
+          yarn
+      - name: Lint Check
+        if: ${{ success() }}
+        run: |
+          yarn lint
+      - name: Code Format Check
+        if: ${{ success() }}
+        run: |
+          yarn prettier

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -6,5 +6,5 @@ const buildEslintCommand = (filenames) =>
     .join(" --file ")}`;
 
 module.exports = {
-  "*.{js,jsx,ts,tsx}": [buildEslintCommand, "yarn prettier"],
+  "*.{js,jsx,ts,tsx}": [buildEslintCommand, "yarn prettier:fix"],
 };

--- a/components/UI/FooterBanner/FooterBanner.tsx
+++ b/components/UI/FooterBanner/FooterBanner.tsx
@@ -3,7 +3,11 @@ import styles from "./FooterBanner.module.css";
 export default function FooterBanner() {
   return (
     <span className={styles.footer}>
-     <b>Açıklama:</b> Twitter, Instagram, Whatsapp ve çeşitli web siteleri gibi farklı kaynaklardan gelen tüm yardım çağrılarını topluyoruz ve bu veriyi sahada kullanılmak üzere anlamlı, rafine hale getiriyoruz. Amacımız bilgi teknolojilerini kullanarak ilgili kurum ve STK&apos;lara yardımcı olmak ve afet zamanlarında açık bir veri platformu sağlamak.
+      <b>Açıklama:</b> Twitter, Instagram, Whatsapp ve çeşitli web siteleri gibi
+      farklı kaynaklardan gelen tüm yardım çağrılarını topluyoruz ve bu veriyi
+      sahada kullanılmak üzere anlamlı, rafine hale getiriyoruz. Amacımız bilgi
+      teknolojilerini kullanarak ilgili kurum ve STK&apos;lara yardımcı olmak ve
+      afet zamanlarında açık bir veri platformu sağlamak.
     </span>
   );
 }

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "dev": "cross-env NODE_OPTIONS='--inspect' next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
-    "prettier": "prettier --write .",
+    "lint": "next lint --max-warnings=0",
+    "lint:fix": "next lint --fix",
+    "prettier": "prettier --check .",
+    "prettier:fix": "prettier --write .",
     "prepare": "husky install"
   },
   "dependencies": {


### PR DESCRIPTION
I do not know do you guys need or not. If not, feel free to decline.

The idea behind using github actions for validating linting and code formatting is anyone can commit with `--no-verify` flag or if something was broken in the developer's computer, s/he can accidentally commit without running git hooks (git hooks might not be injected correctly)