### PR TITLE
docs: fix typo in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 
 ## Katkı yapmadan önce dikkat edilmesi gerekenler
 
-- İlgilendiğiniz konunun daha önce herhangi bir issue tarafından işlenilmediğine ve başkası tarafından yapılmadığından emin olun
-- Eğer bir problemle karşılaşırsanız, issue açınç
+- İlgilendiğiniz konunun daha önce herhangi bir issue tarafından işlenilmediğine ve başkası tarafından yapılmadığından emin olun.
+- Eğer bir problemle karşılaşırsanız, issue açın.
 - Beklediğiniz, istediğiniz bir değişiklik için issue açın.
-- Yeni bir özellik eklemek için issue açın
-- Bir hatayı düzeltmek için PR açın
-- Dökümantasyondaki bir hatayı düzeltmek için PR açın
+- Yeni bir özellik eklemek için issue açın.
+- Bir hatayı düzeltmek için PR açın.
+- Dökümantasyondaki bir hatayı düzeltmek için PR açın.
 
 ## Başlamadan önce
 


### PR DESCRIPTION
This PR is just for a typo fix and missing periods in CONTRIBUTING.md