### PR TITLE
fix: twitter iframe double scroll issue

### DIFF
--- a/components/UI/Drawer/Drawer.module.css
+++ b/components/UI/Drawer/Drawer.module.css
@@ -94,12 +94,11 @@
 }
 
 .sourceContentIframeWrapper {
-  max-height: 350px;
-  overflow: scroll;
+  overflow-y: hidden;
 }
 
 .sourceContentIframe {
-  height: 340px;
+  height: 600px;
 }
 
 .sourceHelpContent {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/23298031/217330682-56106e6e-1b32-4d35-9526-0218748614fb.png)
After:
![image](https://user-images.githubusercontent.com/23298031/217330709-96ca353d-8ff2-493a-b1ef-cce361d5fd40.png)
