### PR TITLE
fix: map center zoom

### DIFF
--- a/components/UI/Map/LeafletMap.tsx
+++ b/components/UI/Map/LeafletMap.tsx
@@ -117,7 +117,6 @@ function LeafletMap() {
         <MapEvents />
         {/* <ImpactedCities /> */}
         <HeatmapLayer
-          fitBoundsOnLoad
           fitBoundsOnUpdate
           radius={15}
           points={points}

--- a/components/UI/Map/utils.ts
+++ b/components/UI/Map/utils.ts
@@ -1,7 +1,7 @@
 import { LatLngBoundsExpression, LatLngExpression } from "leaflet";
 
-export const DEFAULT_CENTER: LatLngExpression = [37.0588348, 37.3450317];
-export const DEFAULT_ZOOM = 6.4;
+export const DEFAULT_CENTER: LatLngExpression = [37.5109968, 37.4376733];
+export const DEFAULT_ZOOM = 8;
 export const DEFAULT_IMPORTANCY = 1;
 export const DEFAULT_MAX_BOUNDS: LatLngBoundsExpression = [
   [39.684006, 31.607263],


### PR DESCRIPTION
HeatmapLayer daki fitBoundsOnLoad attribute u kaldırdık bu koordinat verilsede heatmapleri sığdırmak için geriye çekiyordu şuan istediğim koordinatalar göre ayarlayabiliyoruz