### PR TITLE
"Yardım çağır" demek daha anlamlı duracaktır.

### DIFF
--- a/components/UI/Button/HelpButton.tsx
+++ b/components/UI/Button/HelpButton.tsx
@@ -16,7 +16,7 @@ const _HelpButton = () => {
           <Campaign sx={{ color: "white" }} />
         </div>
       </Link>
-      YARDIM BUTONU
+      YARDIM ÇAĞIR
     </div>
   );
 };


### PR DESCRIPTION
Selam

Yardım butonu yerine "yardım çağır" yazılması daha anlaşılır kalıyor.

Yardıma çağır diye bir söz üzerinde düşündük. Ancak bunun anlamca birisi yardıma gider iken başkalarını yanına çağırmak gibi dar odaklı anlamı olduğu için yardım çağır sözü üzerinde oydaş olduk.

Sağ olunuz.