### PR TITLE
fix: zoom delta zoom out yapilamamasina neden oluyor

### DIFF
--- a/components/UI/Map/LeafletMap.tsx
+++ b/components/UI/Map/LeafletMap.tsx
@@ -132,7 +132,6 @@ function LeafletMap() {
             : DEFAULT_MIN_ZOOM_MOBILE
         }
         whenReady={(map: any) => setCoordinates(map.target.getBounds())}
-        zoomDelta={0.5}
         preferCanvas
         maxBounds={bounds}
         maxBoundsViscosity={1}


### PR DESCRIPTION
closes #372 

`zoomDelta` zoom out butonunu engelliyor. nedenini tam olarak bilemiyorum. onun disinda pek bir UX farki gormedim `zoomDelta` nin varligi (zoom in icin calisiyor sadece) ve yoklugu arasinda.