### PR TITLE
Open Graph improvements

### DIFF
--- a/.github/workflows/notice-yarn-changes.yml
+++ b/.github/workflows/notice-yarn-changes.yml
@@ -1,0 +1,23 @@
+name: notice-yarn-changes
+on:
+  pull_request:
+    branches: [main, development]
+
+jobs:
+  check:
+    name: Publish yarn changes if exist
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Notice yarn.lock changes
+        uses: Simek/yarn-lock-changes@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          collapsibleThreshold: '25'
+          failOnDowngrade: 'false'
+          path: 'yarn.lock'
+          updateComment: 'true'

--- a/components/UI/Map/utils.ts
+++ b/components/UI/Map/utils.ts
@@ -1,7 +1,7 @@
 import { LatLngBoundsExpression, LatLngExpression } from "leaflet";
 
-export const DEFAULT_CENTER: LatLngExpression = [37.5109968, 37.4376733];
-export const DEFAULT_ZOOM = 8;
+export const DEFAULT_CENTER: LatLngExpression = [37.5922732, 36.8989255];
+export const DEFAULT_ZOOM = 14;
 export const DEFAULT_ZOOM_MOBILE = 7.3;
 export const DEFAULT_IMPORTANCY = 1;
 export const DEFAULT_MAX_BOUNDS: LatLngBoundsExpression = [

--- a/components/base/HeadWithMeta/HeadWithMeta.tsx
+++ b/components/base/HeadWithMeta/HeadWithMeta.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { NextSeo } from "next-seo";
+
+// TODO: const below should be replaced with single item service response
+const ADDRESS = "Çekmece, samandağ bulvarı 164/a, 31070 Defne/Hatay, Türkiye";
+const ENTRY =
+  "@ahbap @Ahbap_iletisim ACİL !! Enkazdan kurtulan insanlar Çekmece Mahallesi'nde donuyor. Telefonlarının şarjı bitmek üzere. Hatay Defne İlçesi Çekmece Mahallesi 67. Sokak HECEMAR varmış etraflarında. Onlarca insan çorapsız ayaklarıyla montsuz, susuz, ekmeksiz, korumasız. Lütfen yardım gönderin lütfen!!";
+const LOC = "37.5771529,36.9283658";
+
+// TODO: OG_EDGE_URL should be replace with main API
+const OG_EDGE_URL =
+  "https://deprem-yardim-og-generator.vercel.app/api/dynamic-image";
+
+const HeadWithMeta = () => {
+  return (
+    <NextSeo
+      title={ADDRESS}
+      description={ENTRY}
+      openGraph={{
+        // TODO: base path is missing in next.config static for now
+        url: "https://afetharita.com/",
+        title: ADDRESS,
+        description: ENTRY,
+        images: [
+          {
+            url: `${OG_EDGE_URL}?loc=${encodeURIComponent(
+              LOC
+            )}&address=${encodeURIComponent(
+              ADDRESS
+            )}&entry=${encodeURIComponent(ENTRY)}`,
+            width: 1200,
+            height: 630,
+            alt: `${ADDRESS}`,
+            type: "image/png",
+          },
+        ],
+        siteName: "Afet Haritası",
+      }}
+      twitter={{
+        handle: "@ihtiyacharitasi",
+        cardType: "summary_large_image",
+        site: "@ihtiyacharitasi",
+      }}
+      additionalMetaTags={[
+        {
+          name: "viewport",
+          content: "initial-scale=1, width=device-width",
+        },
+      ]}
+      additionalLinkTags={[
+        {
+          rel: "icon",
+          href: "/favicon.ico",
+        },
+        {
+          rel: "shortcut icon",
+          href: "/favicon.ico",
+        },
+      ]}
+    />
+  );
+};
+export default HeadWithMeta;

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "leaflet.markercluster": "^1.5.3",
     "next": "13.1.6",
     "next-pwa": "^5.6.0",
+    "next-seo": "^5.15.0",
     "notistack": "^2.0.8",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import Head from "next/head";
 import { AppProps } from "next/app";
 import { ThemeProvider } from "@mui/material/styles";
 import CssBaseline from "@mui/material/CssBaseline";
@@ -7,6 +6,7 @@ import { CacheProvider, EmotionCache } from "@emotion/react";
 import theme from "../utils/theme";
 import createEmotionCache from "../utils/createEmotionCache";
 import { SnackbarProvider } from "@/components/base/Snackbar";
+import HeadWithMeta from "@/components/base/HeadWithMeta/HeadWithMeta";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -23,9 +23,10 @@ export default function MyApp(props: MyAppProps) {
   const { Component, emotionCache = clientSideEmotionCache, pageProps } = props;
   return (
     <CacheProvider value={emotionCache}>
-      <Head>
+      {/* <Head>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
-      </Head>
+      </Head> */}
+      <HeadWithMeta />
       <ThemeProvider theme={theme}>
         <SnackbarProvider>
           {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6088,6 +6088,11 @@ next-pwa@^5.6.0:
     workbox-webpack-plugin "^6.5.4"
     workbox-window "^6.5.4"
 
+next-seo@^5.15.0:
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.15.0.tgz#b1a90508599774982909ea44803323c6fb7b50f4"
+  integrity sha512-LGbcY91yDKGMb7YI+28n3g+RuChUkt6pXNpa8FkfKkEmNiJkeRDEXTnnjVtwT9FmMhG6NH8qwHTelGrlYm9rgg==
+
 next@13.1.6:
   version "13.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-13.1.6.tgz#054babe20b601f21f682f197063c9b0b32f1a27c"


### PR DESCRIPTION
npm paketlerinin eklenmesi güncellenmesi gibi durumlarda gözden kaçabilecek mevzular için yarn lock değişiklikleri artık yorum olarak PR'lara basılacak. Bunun için yeni bir github action workflow eklenmiştir.

closes: #378 

devam olarak #355 için yapılan edge function deneme amaçlı statik değerlerle eklendi. issue içerisindeki [ihtiyaç listesi](https://github.com/acikkaynak/deprem-yardim-frontend/issues/355#issuecomment-1421624562) olarak belirttiğim noktalar için backend tarafında geliştirmesi devam eden endpointle beraber TODO etiketleri kapatılacak.

@usirin wip olarak etiketlenebilir