### PR TITLE
fix: max zoomda pinlerin gorunmesi icin coordinate manipulasyonu

### DIFF
--- a/components/UI/Map/LeafletMap.tsx
+++ b/components/UI/Map/LeafletMap.tsx
@@ -75,6 +75,7 @@ const MapEvents = () => {
 
     let localCoordinates = value;
 
+    // https://github.com/acikkaynak/deprem-yardim-frontend/issues/368
     if (zoomLevel === 18) {
       localCoordinates = expandCoordinatesBy(
         localCoordinates,

--- a/components/UI/Map/LeafletMap.tsx
+++ b/components/UI/Map/LeafletMap.tsx
@@ -2,6 +2,7 @@ import Map from "@/components/UI/Map/Map";
 import { useMapClickHandlers } from "@/hooks/useMapClickHandlers";
 import { MarkerData } from "@/mocks/types";
 import { useDevice, useMapActions, useMarkerData } from "@/stores/mapStore";
+import { EXPAND_COORDINATE_BY_VALUE } from "@/utils/constants";
 import ResetViewControl from "@20tab/react-leaflet-resetview";
 import { css, Global } from "@emotion/react";
 import { HeatmapLayerFactory } from "@vgrid/react-leaflet-heatmap-layer";
@@ -69,8 +70,19 @@ const MapEvents = () => {
   const mapZoomLevelRef = useRef(0);
   const { setCoordinates, setPopUpData } = useMapActions();
 
-  const debounced = useDebouncedCallback((value: any) => {
-    setCoordinates(value);
+  const debounced = useDebouncedCallback((value: L.LatLngBounds) => {
+    const zoomLevel = map.getZoom();
+
+    let localCoordinates = value;
+
+    if (zoomLevel === 18) {
+      localCoordinates = expandCoordinatesBy(
+        localCoordinates,
+        EXPAND_COORDINATE_BY_VALUE
+      );
+    }
+
+    setCoordinates(localCoordinates);
   }, 1000);
 
   const map = useMapEvents({
@@ -89,6 +101,16 @@ const MapEvents = () => {
   });
 
   return null;
+};
+
+const expandCoordinatesBy = (coordinates: L.LatLngBounds, value: number) => {
+  const { lat: neLat, lng: neLng } = coordinates.getNorthEast();
+  const { lat: swLat, lng: swLng } = coordinates.getSouthWest();
+
+  const northEast = L.latLng(neLat + value, neLng + value);
+  const southWest = L.latLng(swLat - value, swLng - value);
+
+  return L.latLngBounds(northEast, southWest);
 };
 
 const corners = {

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,1 +1,2 @@
 export const BASE_URL = "https://api.afetharita.com/feeds/areas";
+export const EXPAND_COORDINATE_BY_VALUE = 0.001;


### PR DESCRIPTION
closes #368 

issue'da bahsettigim cozum icin (`bkz. ya da belli bir zoom in levelina geldigimizde yine de biraz daha genis bir bound yollayacagiz.`) gereken degisiklik

`0.001` tamamen uydurdugum bir sayi onun icin daha iyi bir oneri varsa lutfen oyle yapalim

**Tek Pin Ornegi**
Production:
![Screenshot 2023-02-07 at 8 27 58 PM](https://user-images.githubusercontent.com/1498968/217433701-965193f4-c767-485f-a899-2e668fdf3d64.png)

PR:
![Screenshot 2023-02-07 at 8 28 10 PM](https://user-images.githubusercontent.com/1498968/217433732-c8206682-23f0-4805-8fbe-79ee03ace261.png)

**Kalabalik ornek**
Production:
![Screenshot 2023-02-07 at 8 46 24 PM](https://user-images.githubusercontent.com/1498968/217436118-f06b7943-6a97-4640-bbba-135da064c7d8.png)

PR:
![Screenshot 2023-02-07 at 8 46 33 PM](https://user-images.githubusercontent.com/1498968/217436140-93dd01f9-536c-4b67-9ab1-b6ecaeb2673a.png)
