### PR TITLE
feat: Add Lighthouse results for preview URLs to pull requests

### DIFF
--- a/.github/workflows/lighthouse-audit.yaml
+++ b/.github/workflows/lighthouse-audit.yaml
@@ -1,0 +1,107 @@
+
+# https://github.com/OskarAhl/Lighthouse-github-action-comment/blob/main/.github/workflows/lighthouse-on-vercel-preview-url.yml
+# Extended the example implementation above
+
+name: Vercel Preview URL Lighthouse Audit
+on: [push]
+
+permissions:
+  issues: 'write'
+  pull-requests: write
+
+jobs:
+  generate_lighthouse_audit:
+    timeout-minutes: 30
+    if: needs.pr-check.outputs.number != 'null'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: sleep 30
+      - name: vercel-preview-url
+        uses: zentered/vercel-preview-url@v1.1.3
+        id: vercel_preview_url
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        with:
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Preview Link's Lighthouse Score
+        id: lighthouse_audit
+        uses: treosh/lighthouse-ci-action@v3
+        with:
+          urls: ${{ steps.vercel_preview_url.outputs.preview_url }}
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      - name: Canary Environment's Lighthouse Score
+        id: canary_audit
+        uses: treosh/lighthouse-ci-action@v3
+        with:
+          urls: https://rc.afetharita.com/
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+
+      - name: Format lighthouse score
+        id: format_lighthouse_score
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const results = [
+                { link: ${{ steps.lighthouse_audit.outputs.links }}, result: ${{ steps.lighthouse_audit.outputs.manifest }}[0].summary },
+                { link: ${{ steps.canary_audit.outputs.links }}, result: ${{ steps.canary_audit.outputs.manifest }}[0].summary },
+            ]
+
+            const formatResult = (res) => Math.round(res * 100);
+            const score = (score) => (score >= 90 ? "🟢" : score >= 50 ? "🟠" : "🔴");
+            const keys = ["performance", "best-practices", "seo", "pwa"];
+
+            function getScores({ result }) {
+              return [...keys].map(
+                (key) => `${result[key]} ${score(formatResult(result[key]))}`
+              );
+            }
+
+            function createTable() {
+              const scores = results.map((data) => getScores(data));
+              const rows = [];
+
+              for (const [index, key] of keys.entries()) {
+                rows.push(
+                  `<tr>
+                      <td>${key}</td>
+                      <td>${scores[0][index]}</td>
+                      <td>${scores[0][index]}</td>
+                    </tr>`
+                );
+              }
+
+              return `
+                <table>
+                  <tr>
+                    <th>Key</th>
+                    <th>Score</th>
+                    <th></th>
+                  </tr>
+                  <tr>
+                    <td></td>
+                    <td>${Object.keys(results[0].link)[0]}</td>
+                    <td>${Object.keys(results[1].link)[0]}</td>
+                  </tr>
+                  ${rows.join("\n")}
+                </table>
+              `;
+            }
+
+            core.setOutput("comment", createTable());
+
+      - uses: jwalton/gh-find-current-pr@v1
+        id: finder
+
+      - name: Create comment
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ steps.finder.outputs.pr }}
+          body: |
+            ${{ steps.format_lighthouse_score.outputs.comment }}


### PR DESCRIPTION
## İsteğiniz şeyi tanımlayın 
Duzenli olarak Lighthouse sonuclarina bakip sonuclara gore uygulamayi optimize ediyoruz. Bu test sureci manuel olarak ilerliyor. Bu sureci otomatize etmek bizi ciddi bir efordan kurtaracak.

-- bu bilgiyi ekleyiniz
** discord kullanıcı adı: @puskuruk

## Değerlendirdiğiniz alternatifleri tanımlayın
Lighthouse testlerini GH actions ile `rc` URL'i ve Vercel'in urettigi preview URL'inde kosturup gosterebilecegimiz bir comment'i ilgili pull requeste ekleyebiliriz. Bu sayede yaptigimiz degisikligin son urune olan etkisini acikca gorebiliriz.

## Ek Bağlam
#486
[Ornek comment](https://github.com/puskuruk/deprem-yardim-frontend/pull/1#issuecomment-1424868721)