### PR TITLE
fix: remove getInitialProps from _error to prevent build errors

### DIFF
--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,7 +1,7 @@
 import styles from "@/styles/Home.module.css";
 import { NextPage } from "next";
 import { ErrorProps } from "next/error";
-import NextErrorComponent from "next/error";
+// import NextErrorComponent from "next/error";
 import Image from "next/image";
 import Link from "next/link";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -41,9 +41,9 @@ const CustomErrorPage: NextPage<CustomErrorPageProps> = ({ title, detail }) => {
   );
 };
 
-CustomErrorPage.getInitialProps = async (contextData) => {
-  return NextErrorComponent.getInitialProps(contextData);
-};
+// CustomErrorPage.getInitialProps = async (contextData) => {
+//   return NextErrorComponent.getInitialProps(contextData);
+// };
 
 export async function getStaticProps(context: any) {
   return {


### PR DESCRIPTION
# Description

This was causing builds to fail:

![image](https://user-images.githubusercontent.com/1783869/218250937-c79698d5-8d35-4e74-bce4-b1f2b701f22f.png)


**discord username: `umut#3072`**

this is a hotfix without a github issue.

