### PR TITLE
fix(#866): filter empty reason strings from list

### DIFF
--- a/components/UI/Drawer/components/channels/twitter/PlaceholderTweet.tsx
+++ b/components/UI/Drawer/components/channels/twitter/PlaceholderTweet.tsx
@@ -11,9 +11,12 @@ type Props = {
 };
 
 const PlaceholderTweet = ({ source, reason, full_text }: Props) => {
-  const reasons = reason.split(",").map((reason) => {
-    return capitalize(reason);
-  });
+  const reasons = reason
+    .split(",")
+    .filter((s) => s)
+    .map((reason) => {
+      return capitalize(reason);
+    });
 
   return (
     <>


### PR DESCRIPTION
# Description
The Tweet placeholder chips are not filtering empty reasons


** discord username: @isaozler#4498 **


**closes #issue**
https://github.com/acikkaynak/deprem-yardim-frontend/issues/866

