### PR TITLE
fix(914): layers drawer not showing in safari desktop (min-width 768px)

### DIFF
--- a/components/UI/Drawer/Drawer.tsx
+++ b/components/UI/Drawer/Drawer.tsx
@@ -58,6 +58,7 @@ const Drawer = () => {
         anchor={anchor}
         open={isOpen}
         onClose={handleClose}
+        data-is-layer-drawer={!drawerData}
       >
         {!!drawerData && (
           <Content drawerData={drawerData} onCopyBillboard={copyBillboard} />

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,7 @@
+@media (min-width: 768px) {
+  /* Safari desktop hack */
+  [data-is-layer-drawer="true"] .MuiPaper-root {
+    background-color: unset;
+    width: 1px;
+  }
+}


### PR DESCRIPTION
# Description
The Layers Drawer is not showing when the page is visited in Safari Desktop with a viewport of min-width 768px

https://user-images.githubusercontent.com/1378630/218354368-fdff1f28-4f0b-471c-8f85-f8bade8bb9a7.png

**discord username: @isaozler#4498 **

**closes #issue**
https://github.com/acikkaynak/deprem-yardim-frontend/issues/914
