### PR TITLE
fix(#926): Fix incorrect uppercase in filter Menu

### DIFF
--- a/components/UI/FilterMenu/CommonFilterMenu.tsx
+++ b/components/UI/FilterMenu/CommonFilterMenu.tsx
@@ -54,7 +54,7 @@ function CommonFilterMenu<ValueType>({
         onClick={handleClick}
         ariaControls={`${translationPath}-filtrele`}
       >
-        {t(`${translationPath}.${selectedLabel}`)}
+        {t(`${translationPath}.${selectedLabel}`).toLocaleUpperCase()}
       </FilterMenuButton>
       <Menu anchorEl={anchorEl} open={open} onClose={handleClose}>
         {menuOptions.map((option) => (


### PR DESCRIPTION
# Description
Fixed incorrect uppercase in filter menu options.


**discord username: Sertcast#8543**


**closes #926**

