### PR TITLE
fix(#931): babala drawerData displayed as json

### DIFF
--- a/components/UI/Drawer/components/channels/FeedContent.tsx
+++ b/components/UI/Drawer/components/channels/FeedContent.tsx
@@ -25,7 +25,7 @@ const contentMapper = {
   twitter: (source: FeedChannelTwitterProps) => (
     <FeedChannelTwitter {...source} />
   ),
-  Babala: (source: FeedChannelBabalaProps) => <FeedChannelBabala {...source} />,
+  babala: (source: FeedChannelBabalaProps) => <FeedChannelBabala {...source} />,
   ahbap: (source: FeedChannelAhbapProps) => <FeedChannelAhbap {...source} />,
   teleteyit: (source: FeedChannelTeleteyitProps) => (
     // @ts-ignore


### PR DESCRIPTION
# Description
A typo was causing babala data to be displayed in json format.

**closes #931**
