### PR TITLE
fix: use safe functions to wrap localstorage usage

### DIFF
--- a/components/UI/Map/LeafletMap.tsx
+++ b/components/UI/Map/LeafletMap.tsx
@@ -25,6 +25,8 @@ import {
   DEFAULT_MIN_ZOOM_DESKTOP,
   DEFAULT_MIN_ZOOM_MOBILE,
   localStorageKeys,
+  safeGetLocalStorage,
+  safeSetLocalStorage,
 } from "./utils";
 import LayerControl, { Point } from "./LayerControl";
 import ViewControl from "./ViewControl";
@@ -67,7 +69,7 @@ const MapEvents = () => {
   const locale = router.locale;
 
   useEffect(() => {
-    const localCoordinatesURL = window.localStorage.getItem(
+    const localCoordinatesURL = safeGetLocalStorage(
       localStorageKeys.coordinatesURL
     );
 
@@ -97,10 +99,7 @@ const MapEvents = () => {
 
     return () => {
       const coordinatesURL = window.location.hash;
-      window.localStorage.setItem(
-        localStorageKeys.coordinatesURL,
-        coordinatesURL
-      );
+      safeSetLocalStorage(localStorageKeys.coordinatesURL, coordinatesURL);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -137,7 +136,7 @@ const MapEvents = () => {
         locationWithZoomLevel.append("id", id.toString());
       }
       const query = locationWithZoomLevel.toString();
-      window.localStorage.setItem(localStorageKeys.coordinatesURL, query);
+      safeSetLocalStorage(localStorageKeys.coordinatesURL, query);
 
       router.push(
         { query },

--- a/components/UI/Map/utils.ts
+++ b/components/UI/Map/utils.ts
@@ -18,3 +18,19 @@ export const localStorageKeys = {
 export const localForageKeys = {
   markersVisited: "markersVisited",
 } as const;
+
+export const safeGetLocalStorage = (key: string) => {
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+export const safeSetLocalStorage = (key: string, value: string): void => {
+  try {
+    return window.localStorage.setItem(key, value);
+  } catch {
+    //
+  }
+};

--- a/hooks/useDefaultCenter.tsx
+++ b/hooks/useDefaultCenter.tsx
@@ -1,11 +1,8 @@
 import {
   DEFAULT_CENTER,
-  DEFAULT_ZOOM,
-  DEFAULT_ZOOM_MOBILE,
   localStorageKeys,
+  safeGetLocalStorage,
 } from "@/components/UI/Map/utils";
-import { useDevice } from "@/stores/mapStore";
-import { LatLngExpression } from "leaflet";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
@@ -23,7 +20,7 @@ export default function useDefaultCenter() {
     }
 
     const savedURLSearchParams = new URLSearchParams(
-      window.localStorage.getItem(localStorageKeys.coordinatesURL) || ""
+      safeGetLocalStorage(localStorageKeys.coordinatesURL) ?? ""
     );
     if (savedURLSearchParams.has("lat") && savedURLSearchParams.has("lng")) {
       setDefaultCenter([

--- a/hooks/useDefaultZoom.tsx
+++ b/hooks/useDefaultZoom.tsx
@@ -2,6 +2,7 @@ import {
   DEFAULT_ZOOM,
   DEFAULT_ZOOM_MOBILE,
   localStorageKeys,
+  safeGetLocalStorage,
 } from "@/components/UI/Map/utils";
 import { useDevice } from "@/stores/mapStore";
 import { useRouter } from "next/router";
@@ -22,7 +23,7 @@ export default function useDefaultZoom() {
     }
 
     const savedZoomValue = new URLSearchParams(
-      window.localStorage.getItem(localStorageKeys.coordinatesURL) || ""
+      safeGetLocalStorage(localStorageKeys.coordinatesURL) ?? ""
     )?.get("zoom");
     if (savedZoomValue) {
       setDefaultZoom(parseFloat(savedZoomValue));


### PR DESCRIPTION
# Description

Makes sure we don't fail when browser tries to read from/write to local storage

There is no issue for this, this is to hotfix the mynet iframe usage.
