### PR TITLE
fix(#921): i18n added to error page (wip)

### DIFF
--- a/components/base/ErrorBoundary/index.tsx
+++ b/components/base/ErrorBoundary/index.tsx
@@ -2,8 +2,10 @@ import { DefaultError, MaintenanceError } from "@/errors";
 import CustomErrorPage from "@/pages/_error";
 import type { ReactNode } from "react";
 import { Component } from "react";
+import { TFunction, withTranslation } from "next-i18next";
 
 interface Props {
+  t: TFunction;
   children: ReactNode;
 }
 
@@ -21,8 +23,11 @@ const isTypeError = (error: Error): error is TypeError => {
   return error.name === "TypeError";
 };
 
-const isMaintenanceError = (error: Error): error is MaintenanceError => {
-  return error.name === "Bakımdayız";
+const isMaintenanceError = (
+  error: Error,
+  t: TFunction
+): error is MaintenanceError => {
+  return error.name === t("maintenance.title");
 };
 
 class ErrorBoundary extends Component<Props, State> {
@@ -46,7 +51,7 @@ class ErrorBoundary extends Component<Props, State> {
 
   public render() {
     if (hasError(this.state.hasError, this.state.error)) {
-      if (isMaintenanceError(this.state.error)) {
+      if (isMaintenanceError(this.state.error, this.props.t)) {
         return (
           <CustomErrorPage
             title={this.state.error.name}
@@ -59,9 +64,9 @@ class ErrorBoundary extends Component<Props, State> {
       return (
         <CustomErrorPage
           // @ts-expect-error IDK why this is causing problem, we're safe inside hasError closure
-          title={this.state.error.name}
+          title={this.props.t("defaults.title") || this.state.error.name}
           // @ts-expect-error IDK why this is causing problem, we're safe inside hasError closure
-          detail={this.state.error.message}
+          detail={this.props.t("defaults.detail") || this.state.error.message}
           statusCode={400}
         />
       );
@@ -71,4 +76,4 @@ class ErrorBoundary extends Component<Props, State> {
   }
 }
 
-export default ErrorBoundary;
+export default withTranslation("error")(ErrorBoundary);

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -208,7 +208,11 @@ export async function getServerSideProps(context: any) {
 
   return {
     props: {
-      ...(await serverSideTranslations(context.locale, ["common", "home"])),
+      ...(await serverSideTranslations(context.locale, [
+        "common",
+        "error",
+        "home",
+      ])),
       deviceType: isMobile ? "mobile" : "desktop",
       ahbap: [],
       singleItemDetail: context.query.id

--- a/public/locales/en/error.json
+++ b/public/locales/en/error.json
@@ -7,5 +7,9 @@
         "title": "Error",
         "detail": "Technical error encountered, please try again."
     },
+    "maintenance": {
+        "title": "Maintenance",
+        "detail": "We are currently performing maintenance. Please try again later."
+    },
     "returnHome": "Return to home"
 }

--- a/public/locales/tr/error.json
+++ b/public/locales/tr/error.json
@@ -7,5 +7,9 @@
         "title": "Hata",
         "detail": "Teknik hatayla karşılaşıldı, lütfen tekrar deneyin."
     },
+    "maintenance": {
+        "title": "Bakımdayız",
+        "detail": "Şu anda bakım yapılıyor. Lütfen daha sonra tekrar deneyin."
+    },
     "returnHome": "Anasayfaya dön"
 }


### PR DESCRIPTION
# Description

i18n not working in ErrorBoundary.

**discord username: Yogi#0330**


**closes #921**


1. Error translation file added to root page.
2. 18next's withTranslation hoc method added.


## Things to check before creating a PR
- [ ] I have inspected my topic, checked.
- [ ] If it is a core feature, executed detailed tests.

## Creating PR rules
- [ ] PR must be created for an issue with approved tag. Otherwise PR will be rejected.
- [ ] Relevant issue number: The issue number related to PR must be attached to head of PR header, after prefix after prefix # must be attached in parenthesis. A header like this could be used "prefix(#issue_number): PR header" .
- [ ] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules. For example, a title like "docs(#issueId): Add README.md" can be used.
- [ ] Related file selection: Only relevant files should be touched and no other files should be affected.
- [ ] Format and Lint Suitability : The code should be made in accordance with a certain format standard and examined according to the lint rules.
- [ ] Clean commit history: The commits where the changes are made should be clear and organized.
- [ ] Opening PR when job is completed: PR should be opened when job is completed and sent for review by other team members.



## Changes

- [ ] A new feature (a change that adds a new feature, not a breaking change)
- [ ] A new refactor (a change that is not a breaking change, that improves the readability or performance of the code)
- [ ] A breaking change
- [ ] Documentation change


# How were these changes tested?

Please describe the tests you did to test the changes you made. Please also specify your test configuration.


**Test Configuration**:

* Firmware version:
* Hardware:
* Toolchain:
* SDK:

