### PR TITLE
fix: reason filter has some duplicate fields #1142

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -90,9 +90,18 @@ export async function getServerSideProps(context: any) {
       /Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i
     )
   );
+
+  //Filter out duplicates, put "enkaz (wreckage)" on top
+  const reasonsPresent = new Set<string>();
+  let filteredReasons = reasons.filter((reason) => {
+    const filterCondition = !reasonsPresent.has(reason);
+    reasonsPresent.add(reason);
+    return filterCondition;
+  });
+
   if (context.query.reasons === "" || !context.query.reasons) {
     searchParams.delete("reasons");
-    searchParams.append("reasons", reasons.join(","));
+    searchParams.append("reasons", filteredReasons.join(","));
     redirect = true;
   }
 
@@ -108,7 +117,7 @@ export async function getServerSideProps(context: any) {
     props: {
       ...(await serverSideTranslations(context.locale, ["common", "home"])),
       deviceType: isMobile ? "mobile" : "desktop",
-      reasons,
+      reasons: filteredReasons,
       channel,
       apiResponse,
     },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -92,12 +92,8 @@ export async function getServerSideProps(context: any) {
   );
 
   //Filter out duplicates, put "enkaz (wreckage)" on top
-  const reasonsPresent = new Set<string>();
-  let filteredReasons = reasons.filter((reason) => {
-    const filterCondition = !reasonsPresent.has(reason);
-    reasonsPresent.add(reason);
-    return filterCondition;
-  });
+  const reasonsPresent = new Set<string>([...reasons]);
+  let filteredReasons = Array.from(reasonsPresent);
 
   if (context.query.reasons === "" || !context.query.reasons) {
     searchParams.delete("reasons");


### PR DESCRIPTION
# Description
Reason filter dropdown had some duplicate fields.


**discord username: bumshaqalaqa#2973 **


**closes #1142 **

I have filtered the reasons right after fetching them on the server side.


## Things to check before creating a PR
- [X] I have inspected my topic, checked.
- [ ] If it is a core feature, executed detailed tests.

## Creating PR rules
- [X] PR must be created for an issue with approved tag. Otherwise PR will be rejected.
- [X] Relevant issue number: The issue number related to PR must be attached to head of PR header, after prefix after prefix # must be attached in parenthesis. A header like this could be used "prefix(#issue_number): PR header" .
- [X] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules. For example, a title like "docs(#issueId): Add README.md" can be used.
- [X] Related file selection: Only relevant files should be touched and no other files should be affected.
- [X] Format and Lint Suitability : The code should be made in accordance with a certain format standard and examined according to the lint rules.
- [X] Clean commit history: The commits where the changes are made should be clear and organized.
- [X] Opening PR when job is completed: PR should be opened when job is completed and sent for review by other team members.



## Changes

- [X] A new feature (a change that adds a new feature, not a breaking change)
- [ ] A new refactor (a change that is not a breaking change, that improves the readability or performance of the code)
- [ ] A breaking change
- [ ] Documentation change
