### PR TITLE
fix(#1141): remove auto text transform from MUI buttons

### DIFF
--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -80,6 +80,15 @@ const theme = createTheme({
   typography: {
     fontFamily: inter.style.fontFamily,
   },
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        root: {
+          textTransform: "none",
+        },
+      },
+    },
+  },
 });
 
 export default responsiveFontSizes(theme);


### PR DESCRIPTION
# Description
Due to MUI default styling, texts inside buttons are capitalized incorrectly. Fixed the issue by overwriting MUI styling.


**discord username: Sertcast#8543**


**closes #1141**