### PR TITLE
fix(#1127): Fix satellite layer loading issue at min zooom

### DIFF
--- a/src/components/UI/Map/utils.ts
+++ b/src/components/UI/Map/utils.ts
@@ -8,8 +8,8 @@ export const DEFAULT_MAX_BOUNDS: LatLngBoundsExpression = [
   [39.684006, 31.607263],
   [35.459834, 45.281141],
 ];
-export const DEFAULT_MIN_ZOOM_DESKTOP = 6.4;
-export const DEFAULT_MIN_ZOOM_MOBILE = 4.5;
+export const DEFAULT_MIN_ZOOM_DESKTOP = 7;
+export const DEFAULT_MIN_ZOOM_MOBILE = 4;
 
 export const localStorageKeys = {
   coordinatesURL: "coordinatesURL",


### PR DESCRIPTION
# Description
Set default min zoom to an integer to fix loading issue when switched into satellite layer.

**discord username: Sertcast#8543**


**closes #1127**