### PR TITLE
fix: change button html order to fix double click to zoom problem

### DIFF
--- a/src/newlayout/components/map/MapContent.tsx
+++ b/src/newlayout/components/map/MapContent.tsx
@@ -153,11 +153,10 @@ export const MapContent = ({
         <MapControls filters={{ reasons }} />
         <TileLayer url={baseMapUrl} />
         <LayerControl locations={locations} onMarkerClick={onMarkerClick} />
-
-        <Box sx={styles.fixedMidBottom}>
-          <CooldownButtonComponent />
-        </Box>
       </Map>
+      <Box sx={styles.fixedMidBottom}>
+        <CooldownButtonComponent />
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
partial fix for #1136 

fixes it for only the scan button, which should be 90% of the cases where users are accidentally double clicking to a map control.