### PR TITLE
feat: enable data from teyit_enkaz channel

### DIFF
--- a/src/hooks/useVerifiedLocations.tsx
+++ b/src/hooks/useVerifiedLocations.tsx
@@ -22,6 +22,8 @@ import {
   SatelliteResponse,
   TeleteyitData,
   TeleteyitResponse,
+  TeyitEnkazData,
+  TeyitEnkazResponse,
   TwitterData,
   TwitterResponse,
 } from "@/types";
@@ -200,6 +202,23 @@ export const transformBabalaResponse: RT<BabalaResponse, BabalaData> = (
   };
 };
 
+export const transformTeyitEnkazResponse: RT<
+  TeyitEnkazResponse,
+  TeyitEnkazData
+> = (res) => {
+  return {
+    channel: "teyit_enkaz",
+    geometry: createGeometry(res),
+    properties: {
+      name: res.extraParams?.name ?? null,
+      description: res.extraParams?.description ?? null,
+      type: res.extraParams?.styleUrl ?? null,
+      icon: null, // TODO: fix this after we have an icon
+    },
+    reference: res.entry_id ?? null,
+  };
+};
+
 export const transformers: Record<APIChannel, RT> = {
   ahbap_location: transformAhbapResponse as RT,
   eczane_excel: transformPharmacyResponse as RT,
@@ -212,6 +231,7 @@ export const transformers: Record<APIChannel, RT> = {
   uydu: transformSatelliteResponse as RT,
   twitter: transformTwitterResponse as RT,
   babala: transformBabalaResponse as RT,
+  teyit_enkaz: transformTeyitEnkazResponse as RT,
 };
 
 export function useVerifiedLocations() {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type APIChannel =
   | "eczane_excel"
   | "guvenli_yerler_oteller"
   | "twitter"
+  | "teyit_enkaz"
   | "babala";
 
 export type APIResponse<TChannel extends APIChannel = APIChannel> = {
@@ -348,6 +349,32 @@ export type FoodData = {
   geometry: Geometry;
 };
 
+// Type definitions for Food
+export type TeyitEnkazAPIExtraParams = {
+  name: string;
+  styleUrl: string;
+  icon: string;
+  description?: string;
+};
+
+export type TeyitEnkazResponse = APIResponseObject<
+  "sicak_yemek",
+  TeyitEnkazAPIExtraParams
+>;
+
+export type TeyitEnkazDataProperties = {
+  name: string | null;
+  description: string | null;
+  type: string | null;
+  icon: string | null;
+};
+
+export type TeyitEnkazData = {
+  channel: "teyit_enkaz";
+  properties: TeyitEnkazDataProperties;
+  geometry: Geometry;
+};
+
 export type DataProperties =
   | TwitterData
   | BabalaData
@@ -358,7 +385,8 @@ export type DataProperties =
   | PharmacyData
   | SafePlaceData
   | FoodData
-  | HospitalData;
+  | HospitalData
+  | TeyitEnkazData;
 
 export type ChannelData = DataProperties & {
   reference?: number | null;


### PR DESCRIPTION
Starts showing data from `teyit_enkaz` channel.

Closes #1158 

This is an example of how easy it is to show data from a new channel in new architecture.