### PR TITLE
docs: Add gitpod configuration to make it easier for new contributors to start coding

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM gitpod/workspace-full-vnc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,15 @@
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 3000
+    description: Front end
+    onOpen: open-browser
+    visibility: public
+
+tasks:
+  - before: |
+      mv .env.sample .env.development
+  - init: |
+      yarn
+      yarn dev

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ yarn dev
 ```
 
 You can open up the [http://localhost:3000](http://localhost:3000) address on your browser to see the result.
+
+## Alternatively for local development, you can use Gitpod
+You can use Gitpod to start coding immediately
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/acikyazilimagi/deprem-yardim-frontend) 


### PR DESCRIPTION
# Description

[Gitpod](https://www.gitpod.io/docs/introduction/learn-gitpod) is an **open source** cloud development environment (CDE) which is an on-demand development environment that is pre-configured with all tools, libraries and dependencies needed to write and review code. It is basically an open source alternative with free plan to Github codespaces.

I believe having a gitpod in the project would be very useful when you are expecting quick contributions from many developers in crisis times. Contributors can spin up development environment in 5-10 min without any local environment setup. 
I added the first PR only for this project's front-end to start the discussion. If it is find useful, we can proceed with back-end of this project and other projects. 

In order to test, just click the button below. 

## Changes

- [ ] A new feature (a change that adds a new feature, not a breaking change)
- [ ] A new refactor (a change that is not a breaking change, that improves the readability or performance of the code)
- [ ] A breaking change
- [X] Documentation change


# How were these changes tested?

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/sinansonmez/deprem-yardim-frontend/tree/add-gitpod)
